### PR TITLE
Add GameSettingsConfiguratin to setup the GameSettings

### DIFF
--- a/Assets/Configs/ConfigurationMaster.asset
+++ b/Assets/Configs/ConfigurationMaster.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: ConfigurationMaster
   m_EditorClassIdentifier: 
   configurations:
+  - {fileID: 11400000, guid: 29cc2af331d89354cb9081b462c487b9, type: 2}
   - {fileID: 11400000, guid: 02be577a8a6101548858871999d2f537, type: 2}
   - {fileID: 11400000, guid: 7ba88ebcc660ad54689cc6b933734a03, type: 2}
   - {fileID: 11400000, guid: 9b77b1cc5e0412a488d0145cb1b6044e, type: 2}

--- a/Assets/Scripts/Configurations/GameSettingsConfiguration.cs
+++ b/Assets/Scripts/Configurations/GameSettingsConfiguration.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+
+namespace MultiPong.Configurations
+{
+    using Settings;
+    using Data.Settings;
+    using Values;
+
+    [CreateAssetMenu(
+        fileName = nameof(GameSettingsConfiguration), 
+        menuName = AssetMenu.SETTINGS + "/" + nameof(GameSettingsConfiguration)
+    )]
+    public class GameSettingsConfiguration : BaseConfiguration<GameSettings>
+    {
+        [SerializeField] private NetworkSettingsData network;
+        [SerializeField] private GameplaySettingsData gameplay;
+
+        public override void Configure(GameSettings target)
+        {
+            target.Setup(network, gameplay);
+        }
+    }
+}

--- a/Assets/Scripts/Configurations/GameSettingsConfiguration.cs.meta
+++ b/Assets/Scripts/Configurations/GameSettingsConfiguration.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 626bff817d4c34940956cd11f44f3c46
+guid: 714bf74c57ac00a4db5c0b78859bebc0
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Scripts/Managers/Game/GameInitializer.cs
+++ b/Assets/Scripts/Managers/Game/GameInitializer.cs
@@ -5,6 +5,7 @@ namespace MultiPong.Managers.Game
     using Foundation;
     using Managers;
     using Services;
+    using Settings;
     using Configurations;
 
     public class GameInitializer
@@ -38,6 +39,7 @@ namespace MultiPong.Managers.Game
             {
                 InitializeServiceLocator();
                 InitializeConfigurationService();
+                InitializeGameSettings();
             }
 
             void InitializeRootManagers()
@@ -87,6 +89,11 @@ namespace MultiPong.Managers.Game
             configurerService = new ConfigurerService();
             configurerService.Initialize();
             configurationMaster.Register(configurerService);
+        }
+
+        private void InitializeGameSettings()
+        {
+            var GameSettings = new GameSettings();
         }
 
         private void InitializeEventManager()

--- a/Assets/Scripts/Settings/GameSettings.cs
+++ b/Assets/Scripts/Settings/GameSettings.cs
@@ -1,21 +1,12 @@
-using UnityEngine;
-
 namespace MultiPong.Settings
 {
+    using Services;
     using Data.Settings;
-    using Values;
 
-    [CreateAssetMenu(
-        fileName = nameof(GameSettings), 
-        menuName = AssetMenu.SETTINGS + "/" + nameof(GameSettings)
-    )]
-    public class GameSettings : ScriptableObject
+    public class GameSettings
     {
-        [SerializeField] private NetworkSettingsData network;
-        [SerializeField] private GameplaySettingsData gameplay;
-
-        public NetworkSettingsData Network => network;
-        public GameplaySettingsData Gameplay => gameplay;
+        public NetworkSettingsData Network { get; private set; }
+        public GameplaySettingsData Gameplay { get; private set; }
 
         public static GameSettings Instance;
 
@@ -25,6 +16,14 @@ namespace MultiPong.Settings
                 return;
             
             Instance = this;
+
+            ServiceLocator.Find<ConfigurerService>().Configure(this);
+        }
+
+        public void Setup(NetworkSettingsData network, GameplaySettingsData gameplay)
+        {
+            this.Network = network;
+            this.Gameplay = gameplay;
         }
     }
 }


### PR DESCRIPTION
A bug in the build mode occurred because we couldn't construct singleton `GameSettings` scriptable object in the build. That's worked just in the editor mode. So I added a configuration for `GameSettings` and the problem was solved.